### PR TITLE
Add programmatic migrations inside libs/drizzle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules/
 dist/
 .env
 *.log
-drizzle/

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
   schema: "./src/libs/drizzle/schema.ts",
-  out: "./drizzle",
+  out: "./src/libs/drizzle/migrations",
   dialect: "postgresql",
   dbCredentials: {
     url: process.env.DATABASE_URL!,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "bun run --watch src/index.ts",
     "start": "bun run src/index.ts",
     "db:generate": "drizzle-kit generate",
+    "db:migrate": "bun run src/libs/drizzle/migrate.ts",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "ingest:discord": "bun run src/ingestion/discord-scraper.ts",

--- a/src/libs/drizzle/index.ts
+++ b/src/libs/drizzle/index.ts
@@ -1,0 +1,11 @@
+export { db, type Database } from "./client";
+export {
+  knowledgeBase,
+  sourceTypeEnum,
+  type KnowledgeBaseRecord,
+  type NewKnowledgeBaseRecord,
+} from "./schema";
+export { runMigrations } from "./migrate";
+export { sql } from "drizzle-orm";
+export type { PgTable, TableConfig } from "drizzle-orm/pg-core";
+export type { InferInsertModel } from "drizzle-orm";

--- a/src/libs/drizzle/migrate.ts
+++ b/src/libs/drizzle/migrate.ts
@@ -1,0 +1,14 @@
+import { join } from "node:path";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { db } from "./client";
+
+const migrationsFolder = join(import.meta.dir, "migrations");
+
+export async function runMigrations() {
+  await migrate(db, { migrationsFolder });
+}
+
+// Auto-run when executed as a script
+await runMigrations();
+console.log("Migrations applied successfully.");
+process.exit(0);


### PR DESCRIPTION
## Summary
- Move drizzle-kit output from root `./drizzle` to `src/libs/drizzle/migrations/` so schema and migrations are co-located
- Add `migrate.ts` using `drizzle-orm/postgres-js/migrator` for programmatic migration runs
- Add `db:migrate` npm script (`bun run src/libs/drizzle/migrate.ts`)

## Test plan
- [ ] Run `bun run db:generate` and verify SQL files land in `src/libs/drizzle/migrations/`
- [ ] Run `bun run db:migrate` against a local database and confirm migrations apply
- [ ] Run `bunx tsc --noEmit` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)