### PR TITLE
Enhance drizzle: schemas folder, URL validation, safer migrate

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
-  schema: "./src/libs/drizzle/schema.ts",
+  schema: "./src/libs/drizzle/schemas",
   out: "./src/libs/drizzle/migrations",
   dialect: "postgresql",
   dbCredentials: {

--- a/src/libs/drizzle/client.ts
+++ b/src/libs/drizzle/client.ts
@@ -1,0 +1,27 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { env } from "@/env";
+import * as schema from "./schemas";
+
+function validateDatabaseUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (!["postgres:", "postgresql:"].includes(parsed.protocol)) {
+      throw new Error(`Unsupported protocol "${parsed.protocol}" — expected postgres:// or postgresql://`);
+    }
+    if (!parsed.hostname) {
+      throw new Error("Missing hostname in DATABASE_URL");
+    }
+    return url;
+  } catch (err) {
+    if (err instanceof TypeError) {
+      throw new Error(`Invalid DATABASE_URL: ${url}`);
+    }
+    throw err;
+  }
+}
+
+const client = postgres(validateDatabaseUrl(env.DATABASE_URL));
+export const db = drizzle(client, { schema });
+
+export type Database = typeof db;

--- a/src/libs/drizzle/index.ts
+++ b/src/libs/drizzle/index.ts
@@ -4,7 +4,7 @@ export {
   sourceTypeEnum,
   type KnowledgeBaseRecord,
   type NewKnowledgeBaseRecord,
-} from "./schema";
+} from "./schemas";
 export { runMigrations } from "./migrate";
 export { sql } from "drizzle-orm";
 export type { PgTable, TableConfig } from "drizzle-orm/pg-core";

--- a/src/libs/drizzle/migrate.ts
+++ b/src/libs/drizzle/migrate.ts
@@ -5,10 +5,17 @@ import { db } from "./client";
 const migrationsFolder = join(import.meta.dir, "migrations");
 
 export async function runMigrations() {
+  console.log(`Running migrations from ${migrationsFolder}...`);
   await migrate(db, { migrationsFolder });
+  console.log("Migrations applied successfully.");
 }
 
 // Auto-run when executed as a script
-await runMigrations();
-console.log("Migrations applied successfully.");
-process.exit(0);
+if (import.meta.main) {
+  runMigrations()
+    .then(() => process.exit(0))
+    .catch((err) => {
+      console.error("Migration failed:", err);
+      process.exit(1);
+    });
+}

--- a/src/libs/drizzle/schemas/index.ts
+++ b/src/libs/drizzle/schemas/index.ts
@@ -1,0 +1,6 @@
+export {
+  knowledgeBase,
+  sourceTypeEnum,
+  type KnowledgeBaseRecord,
+  type NewKnowledgeBaseRecord,
+} from "./knowledge-base";

--- a/src/libs/drizzle/schemas/knowledge-base.ts
+++ b/src/libs/drizzle/schemas/knowledge-base.ts
@@ -1,0 +1,38 @@
+import {
+  pgTable,
+  uuid,
+  text,
+  pgEnum,
+  jsonb,
+  timestamp,
+  index,
+  vector,
+} from "drizzle-orm/pg-core";
+
+export const sourceTypeEnum = pgEnum("source_type", [
+  "discord_message",
+  "document",
+]);
+
+export const knowledgeBase = pgTable(
+  "knowledge_base",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    content: text("content").notNull(),
+    embedding: vector("embedding", { dimensions: 1536 }).notNull(),
+    sourceType: sourceTypeEnum("source_type").notNull(),
+    metadata: jsonb("metadata").$type<Record<string, unknown>>().default({}),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index("kb_embedding_idx")
+      .using("hnsw", table.embedding.op("vector_cosine_ops")),
+    index("kb_source_type_idx").on(table.sourceType),
+    index("kb_created_at_idx").on(table.createdAt),
+  ],
+);
+
+export type KnowledgeBaseRecord = typeof knowledgeBase.$inferSelect;
+export type NewKnowledgeBaseRecord = typeof knowledgeBase.$inferInsert;


### PR DESCRIPTION
## Summary
- Move schema into `schemas/` folder with barrel — each table gets its own file for cleaner organization
- Add `DATABASE_URL` validation in `client.ts` (checks valid URL, `postgres://`/`postgresql://` protocol, hostname present)
- Use `import.meta.main` guard in `migrate.ts` so `runMigrations()` can be imported without auto-executing, with proper error handling and logging

## Test plan
- [x] `bunx tsc --noEmit` — zero errors
- [ ] `bun run db:generate` picks up schemas from the new folder
- [ ] `bun run db:migrate` runs with proper logging and exits cleanly
- [ ] Invalid `DATABASE_URL` throws a clear error at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)