### PR TITLE
Fix env credentials, add typecheck, healthcheck, and env validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,17 +2,15 @@
 DISCORD_TOKEN=
 DISCORD_USER_ID=
 
-# Database (PostgreSQL with pgvector)
-DATABASE_URL=postgresql://user:password@localhost:5432/twin
+# Database (PostgreSQL with pgvector — matches docker-compose defaults)
+DATABASE_URL=postgresql://twin:twin@localhost:5432/twin
 
-# OpenAI (embeddings)
+# OpenAI (required for embeddings, regardless of LLM_PROVIDER)
 OPENAI_API_KEY=
 
 # LLM provider: "anthropic" or "google"
 LLM_PROVIDER=anthropic
 
-# Anthropic
+# Provide the API key for your chosen LLM_PROVIDER
 ANTHROPIC_API_KEY=
-
-# Google
-GOOGLE_GENERATIVE_AI_API_KEY=
+# GOOGLE_GENERATIVE_AI_API_KEY=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What is this project?
+
+Twin is a Discord bot that acts as an AI "digital twin" — it learns from a user's Discord messages and documents, then responds mimicking their tone, vocabulary, and knowledge. Uses pgvector for semantic search and Vercel AI SDK for multi-model LLM support (Anthropic Claude / Google Gemini).
+
+## Commands
+
+```bash
+bun run dev                              # Watch mode
+bun start                                # Run bot
+bun run db:generate                      # Generate migration after schema changes
+bun run db:migrate                       # Apply migrations programmatically
+bun run db:push                          # Push schema directly (dev shortcut)
+bun run db:studio                        # Drizzle Studio UI
+bun run ingest:discord <channelId>       # Scrape user messages from a channel
+bun run ingest:docs <directory>          # Ingest .md/.txt documents
+bun run typecheck                        # Type check (bunx tsc --noEmit)
+docker compose up -d                     # Start PostgreSQL + pgvector
+```
+
+## Architecture
+
+### Layer rules
+
+- **`src/libs/`** — Wrappers around npm packages. **Only files inside `libs/` may import from npm packages** (except `zod` in `env.ts` and `node:*` built-ins). Everything else imports from `@/libs/*`.
+- **`src/shared/`** — Base abstractions (`BaseRepository<T>`, `BaseIngestionService`) reused across the app.
+- **`src/knowledge/`** — Domain layer: vector search, prompt building, text chunking.
+- **`src/bot/`** — Discord bot client and message handlers.
+- **`src/ingestion/`** — CLI scripts extending `BaseIngestionService` with async generator `extract()` methods.
+
+### Data flow
+
+1. **Ingestion** — Discord messages or documents are chunked → batch-embedded (OpenAI text-embedding-3-small, 1536d) → stored in PostgreSQL with pgvector.
+2. **Query** — User message triggers bot → query embedded → cosine similarity search against knowledge_base → top 20 results retrieved.
+3. **Response** — System prompt built from search results (style examples + knowledge) → LLM streams response → debounced edits to Discord message.
+
+### Key patterns
+
+- Each `libs/` subdirectory has a barrel `index.ts` — add new exports there.
+- `BaseIngestionService.run()` handles the batch embed→insert pipeline. Subclasses only implement `async *extract(): AsyncGenerator<IngestionItem[]>`.
+- `BaseRepository<TTable>` provides typed `insertMany()`. `KnowledgeRepository` extends it with `search()`.
+- New database tables go in `src/libs/drizzle/schemas/` as separate files, re-exported through the barrel.
+- `drizzle.config.ts` points `schema` at `./src/libs/drizzle/schemas` and `out` at `./src/libs/drizzle/migrations`.
+- Streaming responses use `createStreamEditor()` which debounces Discord message edits at 1500ms and splits overflow into follow-up messages.
+
+### Path alias
+
+`@/*` maps to `src/*` (configured in `tsconfig.json`). Always use `@/` imports for cross-directory references.
+
+## Environment
+
+Runtime is **Bun** (not Node). Database requires **PostgreSQL with pgvector extension** — the `docker-compose.yml` uses `pgvector/pgvector:pg17`. Copy `.env.example` to `.env` and fill in credentials. `LLM_PROVIDER` selects between `anthropic` (Claude Sonnet 4) and `google` (Gemini 2.0 Flash).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg17
+    restart: unless-stopped
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: twin
+      POSTGRES_PASSWORD: twin
+      POSTGRES_DB: twin
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U twin"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "ingest:discord": "bun run src/ingestion/discord-scraper.ts",
-    "ingest:docs": "bun run src/ingestion/document-loader.ts"
+    "ingest:docs": "bun run src/ingestion/document-loader.ts",
+    "typecheck": "bunx tsc --noEmit"
   },
   "dependencies": {
     "ai": "^4.1.0",

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,13 +1,30 @@
 import { z } from "zod";
 
-const envSchema = z.object({
-  DISCORD_TOKEN: z.string().min(1),
-  DISCORD_USER_ID: z.string().min(1),
-  DATABASE_URL: z.string().url(),
-  OPENAI_API_KEY: z.string().min(1),
-  LLM_PROVIDER: z.enum(["anthropic", "google"]).default("anthropic"),
-  ANTHROPIC_API_KEY: z.string().optional(),
-  GOOGLE_GENERATIVE_AI_API_KEY: z.string().optional(),
-});
+const envSchema = z
+  .object({
+    DISCORD_TOKEN: z.string().min(1),
+    DISCORD_USER_ID: z.string().min(1),
+    DATABASE_URL: z.string().url(),
+    OPENAI_API_KEY: z.string().min(1),
+    LLM_PROVIDER: z.enum(["anthropic", "google"]).default("anthropic"),
+    ANTHROPIC_API_KEY: z.string().min(1).optional(),
+    GOOGLE_GENERATIVE_AI_API_KEY: z.string().min(1).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.LLM_PROVIDER === "anthropic" && !data.ANTHROPIC_API_KEY) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "ANTHROPIC_API_KEY is required when LLM_PROVIDER is 'anthropic'",
+        path: ["ANTHROPIC_API_KEY"],
+      });
+    }
+    if (data.LLM_PROVIDER === "google" && !data.GOOGLE_GENERATIVE_AI_API_KEY) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "GOOGLE_GENERATIVE_AI_API_KEY is required when LLM_PROVIDER is 'google'",
+        path: ["GOOGLE_GENERATIVE_AI_API_KEY"],
+      });
+    }
+  });
 
 export const env = envSchema.parse(process.env);


### PR DESCRIPTION
## Summary
- Fix `.env.example` credentials to match `docker-compose.yml` defaults (`twin:twin`), add note that OpenAI is always required for embeddings. Closes #6
- Add `typecheck` script to `package.json` (`bunx tsc --noEmit`). Closes #7
- Add `pg_isready` healthcheck to `docker-compose.yml` postgres service. Closes #8
- Add `.superRefine()` to `env.ts` Zod schema enforcing the matching API key is present for the selected `LLM_PROVIDER`. Closes #9

## Test plan
- [ ] `bun run typecheck` — zero errors
- [ ] `docker compose up -d` — postgres becomes healthy within 25s
- [ ] App crashes at startup with clear Zod error if `LLM_PROVIDER=anthropic` but no `ANTHROPIC_API_KEY`
- [ ] `.env.example` credentials work with `docker compose` out of the box

🤖 Generated with [Claude Code](https://claude.com/claude-code)